### PR TITLE
Instead of referring to the python interpreter at a specific path, use env to locate it.

### DIFF
--- a/check-all-the-things
+++ b/check-all-the-things
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 
 # Copyright 2014-2018 Jakub Wilk <jwilk@jwilk.net>

--- a/check-font-embedding-restrictions
+++ b/check-font-embedding-restrictions
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python
 
 import fontforge
 import debian.deb822 as deb822


### PR DESCRIPTION
This enables `check-all-the-things` to run on macOS (where python3 is installed to `/usr/local/bin/python3` via Homebrew).