### PR TITLE
Support for CIF (chemical/x-cif)

### DIFF
--- a/data/cif.ini
+++ b/data/cif.ini
@@ -9,5 +9,3 @@ debian = cod-tools
 files = *.cif
 types = chemical/x-cif
 command = cif_cod_check {files}
-
-# TODO: cod-tools: cif_hkl_check cif_validate

--- a/data/cif.ini
+++ b/data/cif.ini
@@ -1,1 +1,13 @@
-# TODO: cod-tools: cif_cod_check cif_hkl_check cif_validate cod_predeposition_check ssg_symop_check
+[cifparse]
+debian = cod-tools
+files = *.cif
+types = chemical/x-cif
+command = cifparse {files}
+
+[cif_cod_check]
+debian = cod-tools
+files = *.cif
+types = chemical/x-cif
+command = cif_cod_check {files}
+
+# TODO: cod-tools: cif_hkl_check cif_validate


### PR DESCRIPTION
Previously, `cif.ini` contained a TO DO item for checkers from `cod-tools` Debian package. This PR implements aforementioned TO DO item.