### PR TITLE
BibTeX validator

### DIFF
--- a/data/bibtex.ini
+++ b/data/bibtex.ini
@@ -1,0 +1,5 @@
+[bibtex-validate]
+flags = perl-inc-cwd-bug
+debian = libtext-bibtex-validate-perl (>= 0.3.0)
+files = *.bib
+command = bibtex-validate {files}


### PR DESCRIPTION
This PR adds BibTeX format parser and validator. Debian package performing the check has recently entered Debian unstable, but I assume this is OK, as from `debian/changelog` I gather that check-all-the-things is supposed to be used on unstable. (Not sure though how backports are handled.)