### PR TITLE
Sync back upstream 2017.05.20+nmu1 from downstream Debian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+check-all-the-things (2017.05.20+nmu1) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * Drop python2 support; Closes: #942918, #938986
+
+ -- Sandro Tosi <morph@debian.org>  Sat, 07 Dec 2019 17:37:15 -0500
+
 check-all-the-things (2017.05.20) unstable; urgency=medium
 
   * New release.


### PR DESCRIPTION
Sandro Tosi uploaded 2017.05.20+nmu1 in
https://tracker.debian.org/news/1086699/accepted-check-all-the-things-20170520nmu1-source-into-unstable/

However, it was never submitted upstream and thus the debian/changelog in Debian diverged. Sync back to upstream so that debian/changelog is consistent when next upload to Debian happens. stays consistent.

Latest upstream source was downloaded with dgit to make the upstream version is latest possible. Temporary branches https://github.com/ottok/check-all-the-things/tree/check-all-the-things-2017.05.20%2Bnmu1 and https://github.com/ottok/check-all-the-things/tree/check-all-the-things-2017.05.20%2Bnmu1-merge. I am confident that indeed `debian/changelog` is the only change that has not been superseded by any upstream commit, and needs to be merged back upstream.

![Screenshot from 2024-01-25 21-24-34](https://github.com/collab-qa/check-all-the-things/assets/668724/e67b2c5c-6073-422b-a935-045fd0307e4b)
