### PR TITLE
Fix Debian build by using correct register-python-argcomplete

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -17,6 +17,6 @@ override_dh_auto_build:
 		--name="Check all of the things!" \
 		./$P \
 		> $P.1
-	register-python-argcomplete3 check-all-the-things > debian/$P.bash-completion
+	register-python-argcomplete check-all-the-things > debian/$P.bash-completion
 	sed -i s/_python_argcomplete/_check_all_the_things_argcomplete/ debian/$P.bash-completion
 	sed -i 's/$$1/check-all-the-things/' debian/$P.bash-completion


### PR DESCRIPTION
Debian does not seem to have a command `python3-argcomplete3` anymore. Instead the command is nowadays without the `3`, see https://packages.debian.org/search?mode=path&suite=bookworm&section=all&arch=any&searchon=contents&keywords=register-python-argcomplete

Build result without this change:

```
dpkg-buildpackage: info: source package check-all-the-things
dpkg-buildpackage: info: source version 2017.05.20~bpo24.04.1~1706246958.9501c04+master
dpkg-buildpackage: info: source distribution noble
 dpkg-source --before-build .
dpkg-buildpackage: info: host architecture amd64
 debian/rules clean
dh clean --parallel --with bash-completion
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_auto_clean -O--parallel
dh_auto_clean: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_clean -O--parallel
dh_clean: warning: Compatibility levels before 10 are deprecated (level 9 in use)
 debian/rules binary
dh binary --parallel --with bash-completion
dh: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   dh_update_autotools_config -O--parallel
   dh_auto_configure -O--parallel
dh_auto_configure: warning: Compatibility levels before 10 are deprecated (level 9 in use)
   debian/rules override_dh_auto_build
make[1]: Entering directory '/<<PKGBUILDDIR>>'
help2man \
	--version-string=2017.05.20~bpo24.04.1~1706246958.9501c04+master \
	--no-info \
	--name="Check all of the things!" \
	./check-all-the-things \
	> check-all-the-things.1
register-python-argcomplete3 check-all-the-things > debian/check-all-the-things.bash-completion
/bin/sh: 1: register-python-argcomplete3: not found
make[1]: *** [debian/rules:15: override_dh_auto_build] Error 127
```

With the change build passes fine.