### PR TITLE
data/nginx.ini: Update gixy reference to actively maintained fork

### DIFF
--- a/data/nginx.ini
+++ b/data/nginx.ini
@@ -1,1 +1,1 @@
-# TODO: https://github.com/yandex/gixy
+# TODO: https://github.com/dvershinin/gixy


### PR DESCRIPTION
The original `yandex/gixy` repository has been unmaintained since 2020.

The [`dvershinin/gixy`](https://github.com/dvershinin/gixy) fork (published as `gixy-ng` on PyPI) is actively maintained with:
- Python 3.6+ support (up to 3.13)
- Additional security checks beyond the original
- Regular updates and releases
- Modern dependency support

Official website: https://gixy.org
Documentation: https://gixy.getpagespeed.com